### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MCP server for managing AI session handoffs and next steps tracking.
 
+<a href="https://glama.ai/mcp/servers/3bjpgw8p74"><img width="380" height="200" src="https://glama.ai/mcp/servers/3bjpgw8p74/badge" alt="Project Handoffs Server MCP server" /></a>
+
 ## Core Concepts
 
 - NextStep → WorkingSession → Handoff → New NextStep chains


### PR DESCRIPTION
This PR adds a badge for the [Project Handoffs MCP Server](https://glama.ai/mcp/servers/3bjpgw8p74) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/3bjpgw8p74"><img width="380" height="200" src="https://glama.ai/mcp/servers/3bjpgw8p74/badge" alt="Project Handoffs Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.